### PR TITLE
feat: step execustion 방식을 이용한 Job 중지 제어

### DIFF
--- a/src/main/java/com/slicequeue/springboot/batch/domain/support/TransactionDaoSupport.java
+++ b/src/main/java/com/slicequeue/springboot/batch/domain/support/TransactionDaoSupport.java
@@ -15,7 +15,7 @@ public class TransactionDaoSupport extends JdbcTemplate implements TransactionDa
   @Override
   public List<Transaction> getTransactionsByAccountNumber(String accountNumber) {
     return query(
-        "select i.id, t.timestamp, t.amount "
+        "select t.id, t.timestamp, t.amount "
             + "from transaction t inner join account_summary a on "
             + "a.id = t.account_summary_id "
             + "where a.account_number = ?",


### PR DESCRIPTION
## 개요
잡 내의 스텝을 재실행 가능하도록 구성하고 중지 트랜지션을 사용하는 방법을 학습함


## 작업 

- TransactionReader 부분 수정
  - 기존 리더 부분에 `@BeforeStep` 부분 추가, 기존 `@AfterStep` 제거 <img width="977" alt="image" src="https://github.com/slicequeue/spring-batch-study-perfect-guide-ch06-03-stop-job-with-stop-transition/assets/75685750/056cb054-a932-4b10-be3e-24e80d610599">
    - stepExecution 설정
  - 기존 읽기 처리에서 푸터 부분 갯수 처리 부분 확인 사전 확인 진행 후 stepExecution의 setTerminationOnly() 처리 <img width="977" alt="image" src="https://github.com/slicequeue/spring-batch-study-perfect-guide-ch06-03-stop-job-with-stop-transition/assets/75685750/1e7d7737-314b-42af-bffa-cd80b6fc1463">

- TransactionJob 부분 수정
  - 위 처리에 따른 Job  흐름 간략화 <img width="979" alt="image" src="https://github.com/slicequeue/spring-batch-study-perfect-guide-ch06-03-stop-job-with-stop-transition/assets/75685750/36fc61b7-a180-4c55-9cd0-b43de61c8fcc">
    - 이렇게 하면 JobInstanceInterrupt 이용해서 중단 가능하다고함...

 
## 실행
<img width="1264" alt="image" src="https://github.com/slicequeue/spring-batch-study-perfect-guide-ch06-03-stop-job-with-stop-transition/assets/75685750/35f0d28e-effc-4df9-9fe8-ead1c7136dcd">
<img width="1267" alt="image" src="https://github.com/slicequeue/spring-batch-study-perfect-guide-ch06-03-stop-job-with-stop-transition/assets/75685750/25b52d4f-3658-4189-95e1-6b7ef81746f8">

- 인스턴스 하나에 재실행 되는 것 확인 실행이 두개 생겼으며 재실행시 파일이 잘못되었는데도 COMPELTE 가 되는데.. 왜그런지는 의문 
- 이전 PR 에서 인스턴스가 재생성되었는데 이는 increamenter 가 추가되어 있어서 발생한 현상으로 생각됨

